### PR TITLE
Add Seccomp.on_trap to hook syscall filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: c
 compiler:
   - gcc

--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -3,6 +3,7 @@ MRuby::Build.new do |conf|
   conf.gembox 'default'
 
   conf.gem mgem: 'mruby-process'
+  conf.gem mgem: 'mruby-uname'
   conf.gem github: 'haconiwa/mruby-exec'
 
   conf.gem '../mruby-seccomp'

--- a/examples/trap.rb
+++ b/examples/trap.rb
@@ -1,0 +1,14 @@
+pid = Process.fork do
+  context = Seccomp.new(default: :allow) do |rule|
+    rule.trap(:uname)
+  end
+  Seccomp.on_trap do |syscall|
+    puts "Trapped: syscall #{Seccomp.syscall_to_name(syscall)} = ##{syscall}"
+  end
+  context.load
+
+  # Then hit `uname`
+  p "nodename: " + Uname.nodename
+end
+
+p(Process.waitpid2 pid)

--- a/examples/trap.rb
+++ b/examples/trap.rb
@@ -7,8 +7,13 @@ pid = Process.fork do
   end
   context.load
 
-  # Then hit `uname`
-  p "nodename: " + Uname.nodename
+  begin
+    # Then hit `uname`
+    p "nodename: " + Uname.nodename
+  rescue => e
+    puts "Catch as error: " + e.message
+    puts "Trapping is OK"
+  end
 end
 
 p(Process.waitpid2 pid)

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -54,4 +54,10 @@ MRuby::Gem::Specification.new('mruby-seccomp') do |spec|
   end
 
   spec.bundle_seccomp
+
+  spec.add_test_dependency 'mruby-print'
+  spec.add_test_dependency 'mruby-io',      mgem: 'mruby-io'
+  spec.add_test_dependency 'mruby-process', mgem: 'mruby-process'
+  spec.add_test_dependency 'mruby-uname',   mgem: 'mruby-uname'
+  spec.add_test_dependency 'mruby-exec',    github: 'haconiwa/mruby-exec'
 end

--- a/mrblib/seccomp.rb
+++ b/mrblib/seccomp.rb
@@ -8,6 +8,14 @@ module Seccomp
       __syscall__table[name.to_s]
     end
 
+    def syscall_to_tupple(i)
+      __syscall__table.find{|p| p[1] == i }
+    end
+
+    def syscall_to_name(i)
+      syscall_to_tupple(i)[0]
+    end
+
     def to_action(action)
       return action if action.is_a?(Integer)
       case action

--- a/test/test_seccomp_context.rb
+++ b/test/test_seccomp_context.rb
@@ -6,3 +6,46 @@ assert("Seccomp::Context.new") do
   ctx = Seccomp::Context.new Seccomp::SCMP_ACT_KILL
   assert_true(ctx.is_a? Seccomp::Context)
 end
+
+assert("Seccomp::Context#kill") do
+  ctx = Seccomp.new(default: :allow) do |rule|
+    rule.kill(:uname)
+  end
+
+  pid = Process.fork do
+    ctx.load
+    exec "/usr/bin/uname", "-a"
+  end
+  pid, ret = Process.waitpid2(pid)
+
+  assert_true(ret.signaled?)
+  assert_equal(ret.termsig, 31) # SYGSIS in Linux
+end
+
+assert("Seccomp.trap") do
+  r, w = IO.pipe
+  pid = Process.fork do
+    r.close
+
+    ctx = Seccomp.new(default: :allow) do |rule|
+      rule.trap(:uname)
+    end
+    Seccomp.on_trap do |sc|
+      data = Seccomp.syscall_to_tupple(sc)
+      w.write data.inspect
+      w.close
+    end
+
+    ctx.load
+    begin
+      "nodename: " + Uname.nodename
+    rescue RuntimeError => e
+      e
+    end
+  end
+  w.close
+  ret = r.read
+  assert_equal('["uname", 63]', ret)
+
+  Process.waitpid2(pid)
+end

--- a/test/test_seccomp_context.rb
+++ b/test/test_seccomp_context.rb
@@ -14,7 +14,7 @@ assert("Seccomp::Context#kill") do
 
   pid = Process.fork do
     ctx.load
-    exec "/usr/bin/uname", "-a"
+    exec "/usr/bin/env", "uname", "-a"
   end
   pid, ret = Process.waitpid2(pid)
 


### PR DESCRIPTION
See `example/trap.rb`:

```ruby
context = Seccomp.new(default: :allow) do |rule|
  rule.trap(:uname)
end
Seccomp.on_trap do |syscall|
  puts "Trapped: syscall #{Seccomp.syscall_to_name(syscall)} = ##{syscall}"
end
context.load

# Then hit `uname`
p "nodename: " + Uname.nodename
```

```
$ mruby/bin/mruby examples/trap.rb
Trapped: syscall uname = #63
```

NOTE: This code of signal trapping way may not be along with UNIX signal programming rules in some case...