### PR TITLE
Support syscall tracing by ptrace

### DIFF
--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -7,5 +7,6 @@ MRuby::Build.new do |conf|
   conf.gem github: 'haconiwa/mruby-exec'
 
   conf.gem '../mruby-seccomp'
+  conf.enable_debug
   conf.enable_test
 end

--- a/examples/tracing.rb
+++ b/examples/tracing.rb
@@ -5,13 +5,14 @@ pid = Process.fork do
   end
   context.load
 
-  # uname will be called 4 times: 1 in bash, 3 in uname(1)
-  exec '/bin/bash', '-c', 'exec uname -a'
+  # uname will be called 10 times: 1 in bash, 3 * 3 in uname(1)
+  exec '/bin/bash', '-c', 'uname -a; uname -a; uname -a'
+  #exec '/bin/bash', '-c', 'exec uname -a'
 end
 
-ret = Seccomp.start_trace(pid) do |syscall, ud|
+ret = Seccomp.start_trace(pid) do |syscall, _pid, ud|
   name = Seccomp.syscall_to_name(syscall)
-  puts "[#{pid}]: syscall #{name}(##{syscall}) called. (ud: #{ud})"
+  puts "[#{_pid}]: syscall #{name}(##{syscall}) called. (ud: #{ud})"
 end
 
 p(ret)

--- a/examples/tracing.rb
+++ b/examples/tracing.rb
@@ -1,0 +1,17 @@
+pid = Process.fork do
+  context = Seccomp.new(default: :allow) do |rule|
+    rule.trace(:getuid, 0)
+    rule.trace(:uname, 0)
+  end
+  context.load
+
+  # uname will be called 4 times: 1 in bash, 3 in uname(1)
+  exec '/bin/bash', '-c', 'exec uname -a'
+end
+
+ret = Seccomp.start_trace(pid) do |syscall, ud|
+  name = Seccomp.syscall_to_name(syscall)
+  puts "[#{pid}]: syscall #{name}(##{syscall}) called. (ud: #{ud})"
+end
+
+p(ret)

--- a/examples/tracing.rb
+++ b/examples/tracing.rb
@@ -8,6 +8,7 @@ pid = Process.fork do
   # uname will be called 10 times: 1 in bash, 3 * 3 in uname(1)
   exec '/bin/bash', '-c', 'uname -a; uname -a; uname -a'
   #exec '/bin/bash', '-c', 'exec uname -a'
+  #exec '/bin/bash', '-l'
 end
 
 ret = Seccomp.start_trace(pid) do |syscall, _pid, ud|

--- a/mrblib/seccomp/context.rb
+++ b/mrblib/seccomp/context.rb
@@ -20,6 +20,14 @@ module Seccomp
       add_rule(Seccomp::SCMP_ACT_TRAP, syscall, *args)
     end
 
+    def trace(syscall, userdata, *args)
+      new_args = []
+      args.each_with_index do |a, i|
+        new_args << a.to_real_operator(i)
+      end
+      __add_rule(Seccomp.to_action(:trace, userdata), Seccomp.to_syscall(syscall), new_args)
+    end
+
     def load!
       ret = load
       if ret < 0

--- a/src/mrb_seccomp.c
+++ b/src/mrb_seccomp.c
@@ -7,8 +7,6 @@
 */
 
 #include "mrb_seccomp.h"
-#include <signal.h>
-#include <stdlib.h>
 
 #define DONE mrb_gc_arena_restore(mrb, 0);
 

--- a/src/mrb_seccomp.h
+++ b/src/mrb_seccomp.h
@@ -7,6 +7,15 @@
 #ifndef MRB_SECCOMP_H
 #define MRB_SECCOMP_H
 
+#include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/class.h>
+#include <mruby/data.h>
+#include <mruby/error.h>
+#include <mruby/variable.h>
+
+#include <seccomp.h>
+
 void mrb_mruby_seccomp_gem_init(mrb_state *mrb);
 
 #endif

--- a/src/mrb_seccomp.h
+++ b/src/mrb_seccomp.h
@@ -15,6 +15,8 @@
 #include <mruby/variable.h>
 
 #include <seccomp.h>
+#include <signal.h>
+#include <stdlib.h>
 
 void mrb_mruby_seccomp_gem_init(mrb_state *mrb);
 

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -1,0 +1,48 @@
+/*
+** tracing.c - Seccomp wrapper around syscall tracing
+**
+** Copyright (c) Uchio Kondo 2016
+**
+** See Copyright Notice in LICENSE
+*/
+
+#include "mrb_seccomp.h"
+
+static void mrb_seccomp_userdata_free(mrb_state *mrb, void *p) {
+  uint16_t *data = (uint16_t *)p;
+  if (data)
+    mrb_free(mrb, data);
+}
+
+static const struct mrb_data_type mrb_seccomp_tracer_type = {
+    "mrb_seccomp_tracer_data", mrb_seccomp_userdata_free,
+};
+
+static mrb_value mrb_seccomp_tracer_init(mrb_state *mrb, mrb_value self) {
+  mrb_int userdata;
+  uint16_t *value = mrb_malloc(mrb, sizeof(uint16_t));
+
+  mrb_get_args(mrb, "i", &userdata);
+  DATA_TYPE(self) = &mrb_seccomp_tracer_type;
+
+  value[0] = (uint16_t)userdata;
+  DATA_PTR(self) = value;
+
+  return self;
+}
+
+uint32_t mrb_seccomp_tracer_to_action(mrb_state *mrb, mrb_value self) {
+  uint16_t *userdata = (uint16_t *)DATA_PTR(self);
+  if (!userdata) {
+    mrb_sys_fail(mrb, "[BUG] userdata is NULL");
+  }
+  return SCMP_ACT_TRACE(userdata[0]);
+}
+
+void mrb_mruby_seccomp_tracing_init(mrb_state *mrb, struct RClass *parent) {
+  struct RClass *tracer =
+      mrb_define_class_under(mrb, parent, "Tracer", mrb->object_class);
+  MRB_SET_INSTANCE_TT(tracer, MRB_TT_DATA);
+  mrb_define_method(mrb, tracer, "initialize", mrb_seccomp_tracer_init,
+                    MRB_ARGS_REQ(1));
+}

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -8,6 +8,12 @@
 
 #include "mrb_seccomp.h"
 
+#include <sys/ptrace.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/user.h>
+#include <sys/wait.h>
+
 static void mrb_seccomp_userdata_free(mrb_state *mrb, void *p) {
   uint16_t *data = (uint16_t *)p;
   if (data)
@@ -39,10 +45,85 @@ uint32_t mrb_seccomp_tracer_to_action(mrb_state *mrb, mrb_value self) {
   return SCMP_ACT_TRACE(userdata[0]);
 }
 
+static int mrb_seccomp_on_tracer_trap(mrb_state *mrb, mrb_value hook,
+                                      pid_t child) {
+  unsigned long msg;
+  struct user_regs_struct regs;
+
+  if (ptrace(PTRACE_GETEVENTMSG, child, NULL, &msg) != 0) {
+    mrb_sys_fail(mrb, "ptrace(PTRACE_GETEVENTMSG...");
+  }
+  if (ptrace(PTRACE_GETREGS, child, NULL, &regs) != 0) {
+    mrb_sys_fail(mrb, "ptrace(PTRACE_GETREGS...");
+  }
+
+  mrb_value args[2];
+  args[0] = mrb_fixnum_value((int)regs.orig_rax); // syscall no
+  args[1] = mrb_fixnum_value((int)msg);           // userdata
+  mrb_yield_argv(mrb, hook, 2, args);
+  return 0;
+}
+
+#define MRB_PTRACE_EVENT(status) (((status >> 8) ^ SIGTRAP) >> 8)
+
+/* This method is implemented unser Seccomp root module */
+static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self) {
+  mrb_int pid;
+  mrb_value hook;
+  int status, child;
+  mrb_get_args(mrb, "i&", &pid, &hook);
+  if (ptrace(PTRACE_ATTACH, (pid_t)pid, NULL, NULL) == -1) {
+    mrb_sys_fail(mrb, "ptrace(PTRACE_ATTACH...");
+  }
+  waitpid(pid, &status, 0);
+
+  if (ptrace(PTRACE_SETOPTIONS, pid, NULL, (void *)PTRACE_O_TRACESECCOMP) ==
+      -1) {
+    mrb_sys_fail(mrb, "ptrace(PTRACE_SETOPTIONS...");
+  }
+  if (ptrace(PTRACE_CONT, pid, NULL, NULL) == -1) {
+    mrb_sys_fail(mrb, "ptrace(PTRACE_CONT...");
+  }
+
+  while (1) {
+    child = waitpid(-1, &status, WUNTRACED | WCONTINUED);
+    if (child == -1) {
+      mrb_sys_fail(mrb, "waitpid");
+    }
+
+    if (WIFEXITED(status)) {
+      return mrb_str_new_lit(mrb, "exited");
+    } else if (WIFSIGNALED(status)) {
+      return mrb_str_new_lit(mrb, "signaled");
+    } else if (WIFSTOPPED(status)) {
+      if (WSTOPSIG(status) == SIGTRAP &&
+          MRB_PTRACE_EVENT(status) == PTRACE_EVENT_SECCOMP) {
+        if (mrb_seccomp_on_tracer_trap(mrb, hook, child) < 0) {
+          mrb_raise(mrb, E_RUNTIME_ERROR, "Something is wrong in trap event");
+        }
+      }
+    } else if (WIFCONTINUED(status)) {
+      /* noop */
+    } else {
+      mrb_raisef(mrb, E_RUNTIME_ERROR, "Got unknown event: %x", status);
+    }
+
+    if (ptrace(PTRACE_CONT, child, NULL, NULL) < 0) {
+      kill(pid, SIGKILL);
+      mrb_raisef(mrb, E_RUNTIME_ERROR,
+                 "Cannot continue process: %d. Force to kill", child);
+    }
+  }
+}
+
 void mrb_mruby_seccomp_tracing_init(mrb_state *mrb, struct RClass *parent) {
   struct RClass *tracer =
       mrb_define_class_under(mrb, parent, "Tracer", mrb->object_class);
   MRB_SET_INSTANCE_TT(tracer, MRB_TT_DATA);
   mrb_define_method(mrb, tracer, "initialize", mrb_seccomp_tracer_init,
                     MRB_ARGS_REQ(1));
+
+  mrb_define_module_function(mrb, parent, "start_trace",
+                             mrb_seccomp_start_ptrace,
+                             MRB_ARGS_REQ(1) | MRB_ARGS_BLOCK());
 }

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -85,8 +85,9 @@ static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self) {
     mrb_sys_fail(mrb, "ptrace(PTRACE_CONT...");
   }
 
+  child = pid;
   while (1) {
-    child = waitpid(-1, &status, WUNTRACED | WCONTINUED);
+    child = waitpid(child, &status, WUNTRACED | WCONTINUED);
     if (child == -1) {
       mrb_sys_fail(mrb, "waitpid");
     }
@@ -109,7 +110,7 @@ static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self) {
     }
 
     if (ptrace(PTRACE_CONT, child, NULL, NULL) < 0) {
-      kill(pid, SIGKILL);
+      kill(child, SIGKILL);
       mrb_raisef(mrb, E_RUNTIME_ERROR,
                  "Cannot continue process: %d. Force to kill", child);
     }

--- a/test/test_seccomp_context.rb
+++ b/test/test_seccomp_context.rb
@@ -22,30 +22,25 @@ assert("Seccomp::Context#kill") do
   assert_equal(ret.termsig, 31) # SYGSIS in Linux
 end
 
-assert("Seccomp.trap") do
-  r, w = IO.pipe
+assert("Seccomp::Context.new") do
+  ctx = Seccomp::Context.new Seccomp::SCMP_ACT_KILL
+  assert_true(ctx.is_a? Seccomp::Context)
+end
+
+assert("Seccomp.start_trace") do
   pid = Process.fork do
-    r.close
-
     ctx = Seccomp.new(default: :allow) do |rule|
-      rule.trap(:uname)
+      rule.trace(:uname, 0)
     end
-    Seccomp.on_trap do |sc|
-      data = Seccomp.syscall_to_tupple(sc)
-      w.write data.inspect
-      w.close
-    end
-
     ctx.load
-    begin
-      "nodename: " + Uname.nodename
-    rescue RuntimeError => e
-      e
-    end
+    exec '/bin/bash', '-c', 'exec uname -a >/dev/null'
   end
-  w.close
-  ret = r.read
-  assert_equal('["uname", 63]', ret)
 
-  Process.waitpid2(pid)
+  count = 0
+  ret = Seccomp.start_trace(pid) do |syscall, ud|
+    count += 1
+  end
+
+  assert_equal "exited", ret
+  assert_equal 4, count
 end

--- a/test/test_seccomp_context.rb
+++ b/test/test_seccomp_context.rb
@@ -44,3 +44,21 @@ assert("Seccomp.start_trace") do
   assert_equal "exited", ret
   assert_equal 4, count
 end
+
+assert("Seccomp.start_trace with forking processes") do
+  pid = Process.fork do
+    ctx = Seccomp.new(default: :allow) do |rule|
+      rule.trace(:uname, 0)
+    end
+    ctx.load
+    exec '/bin/bash', '-c', 'for i in 1 2 3; do uname -a; done'
+  end
+
+  count = 0
+  ret = Seccomp.start_trace(pid) do |syscall, ud|
+    count += 1
+  end
+
+  assert_equal "exited", ret
+  assert_equal 10, count
+end


### PR DESCRIPTION
See example:

```console
$ sudo ./mruby/bin/mruby examples/tracing.rb 
[11833]: syscall getuid(#102) called. (ud: 0)
[11833]: syscall uname(#63) called. (ud: 0)
[11833]: syscall getuid(#102) called. (ud: 0)
[11833]: syscall getuid(#102) called. (ud: 0)
[11833]: syscall getuid(#102) called. (ud: 0)
[11833]: syscall getuid(#102) called. (ud: 0)
[11833]: syscall uname(#63) called. (ud: 0)
[11833]: syscall uname(#63) called. (ud: 0)
[11833]: syscall uname(#63) called. (ud: 0)
"exited"
```