### PR TITLE
Add PTRACE_EVENT_SECCOMP definition if undef

### DIFF
--- a/src/tracing.c
+++ b/src/tracing.c
@@ -14,6 +14,11 @@
 #include <sys/user.h>
 #include <sys/wait.h>
 
+/* At CentOS 7 there seems no definition */
+#ifndef PTRACE_EVENT_SECCOMP
+#define PTRACE_EVENT_SECCOMP 7
+#endif
+
 #ifdef MRB_SECCOMP_DEBUG
 #define _log_p(fmt, ...) fprintf(stderr, fmt, ##__VA_ARGS__)
 #else


### PR DESCRIPTION
Compile error log:

```
/root/rpmbuild/BUILD/haconiwa-0.8.4/mruby/build/mrbgems/mruby-seccomp/src/tracing.c:142:48: error: 'PTRACE_EVENT_SECCOMP' undeclared (first use in this function)
         } else if (MRB_PTRACE_EVENT(status) == PTRACE_EVENT_SECCOMP) {
...
```