### PR TITLE
add start_trace_detach

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: "LLVM"
+IndentWidth: 2
+ColumnLimit: 120
+BreakBeforeBraces: Linux
+AllowShortFunctionsOnASingleLine: None

--- a/src/mrb_seccomp.c
+++ b/src/mrb_seccomp.c
@@ -20,16 +20,20 @@ typedef struct {
   uint32_t def_action;
 } mrb_seccomp_data;
 
-typedef struct { struct scmp_arg_cmp arg_cmp; } mrb_seccomp_arg_cmp_data;
+typedef struct {
+  struct scmp_arg_cmp arg_cmp;
+} mrb_seccomp_arg_cmp_data;
 
-static void mrb_seccomp_free(mrb_state *mrb, void *p) {
+static void mrb_seccomp_free(mrb_state *mrb, void *p)
+{
   mrb_seccomp_data *data = (mrb_seccomp_data *)p;
   if (data && data->ctx)
     seccomp_release(data->ctx);
   mrb_free(mrb, data);
 }
 
-static void mrb_seccomp_arg_cmp_free(mrb_state *mrb, void *p) {
+static void mrb_seccomp_arg_cmp_free(mrb_state *mrb, void *p)
+{
   mrb_seccomp_arg_cmp_data *data = (mrb_seccomp_arg_cmp_data *)p;
   mrb_free(mrb, data);
 }
@@ -44,7 +48,8 @@ static const struct mrb_data_type mrb_seccomp_arg_cmp_data_type = {
 
 uint32_t mrb_seccomp_tracer_to_action(mrb_state *mrb, mrb_value self);
 
-static mrb_value mrb_seccomp_init(mrb_state *mrb, mrb_value self) {
+static mrb_value mrb_seccomp_init(mrb_state *mrb, mrb_value self)
+{
   mrb_seccomp_data *ctx_data;
   mrb_value def_action;
   uint32_t def_action_value;
@@ -75,7 +80,8 @@ static mrb_value mrb_seccomp_init(mrb_state *mrb, mrb_value self) {
   return self;
 }
 
-static mrb_value mrb_seccomp_arg_cmp_init(mrb_state *mrb, mrb_value self) {
+static mrb_value mrb_seccomp_arg_cmp_init(mrb_state *mrb, mrb_value self)
+{
   mrb_seccomp_arg_cmp_data *ac_data;
   mrb_int index, op, datum_a, datum_b = -1;
 
@@ -87,14 +93,11 @@ static mrb_value mrb_seccomp_arg_cmp_init(mrb_state *mrb, mrb_value self) {
   DATA_PTR(self) = NULL;
 
   mrb_get_args(mrb, "iii|i", &index, &op, &datum_a, &datum_b);
-  ac_data = (mrb_seccomp_arg_cmp_data *)mrb_malloc(
-      mrb, sizeof(mrb_seccomp_arg_cmp_data));
+  ac_data = (mrb_seccomp_arg_cmp_data *)mrb_malloc(mrb, sizeof(mrb_seccomp_arg_cmp_data));
   if (datum_b < 0) {
-    ac_data->arg_cmp =
-        (SCMP_CMP((unsigned int)index, (int)op, (uint64_t)datum_a));
+    ac_data->arg_cmp = (SCMP_CMP((unsigned int)index, (int)op, (uint64_t)datum_a));
   } else {
-    ac_data->arg_cmp = (SCMP_CMP((unsigned int)index, (int)op,
-                                 (uint64_t)datum_a, (uint64_t)datum_b));
+    ac_data->arg_cmp = (SCMP_CMP((unsigned int)index, (int)op, (uint64_t)datum_a, (uint64_t)datum_b));
   }
 
   DATA_PTR(self) = ac_data;
@@ -102,10 +105,10 @@ static mrb_value mrb_seccomp_arg_cmp_init(mrb_state *mrb, mrb_value self) {
   return self;
 }
 
-#define MRB_SECCOMP_CMP_FIND(a, i)                                             \
-  (((mrb_seccomp_arg_cmp_data *)(DATA_PTR(mrb_ary_ref(mrb, a, i))))->arg_cmp)
+#define MRB_SECCOMP_CMP_FIND(a, i) (((mrb_seccomp_arg_cmp_data *)(DATA_PTR(mrb_ary_ref(mrb, a, i))))->arg_cmp)
 
-static mrb_value mrb_seccomp_add_rule(mrb_state *mrb, mrb_value self) {
+static mrb_value mrb_seccomp_add_rule(mrb_state *mrb, mrb_value self)
+{
   mrb_seccomp_data *data = DATA_PTR(self);
   uint32_t action;
   int syscall;
@@ -133,41 +136,30 @@ static mrb_value mrb_seccomp_add_rule(mrb_state *mrb, mrb_value self) {
     rc = seccomp_rule_add(data->ctx, action, syscall, 0);
     break;
   case 1:
-    rc = seccomp_rule_add(data->ctx, action, syscall, 1,
-                          MRB_SECCOMP_CMP_FIND(args, 0));
+    rc = seccomp_rule_add(data->ctx, action, syscall, 1, MRB_SECCOMP_CMP_FIND(args, 0));
     break;
   case 2:
-    rc = seccomp_rule_add(data->ctx, action, syscall, 2,
-                          MRB_SECCOMP_CMP_FIND(args, 0),
-                          MRB_SECCOMP_CMP_FIND(args, 1));
+    rc = seccomp_rule_add(data->ctx, action, syscall, 2, MRB_SECCOMP_CMP_FIND(args, 0), MRB_SECCOMP_CMP_FIND(args, 1));
     break;
   case 3:
-    rc = seccomp_rule_add(
-        data->ctx, action, syscall, 3, MRB_SECCOMP_CMP_FIND(args, 0),
-        MRB_SECCOMP_CMP_FIND(args, 1), MRB_SECCOMP_CMP_FIND(args, 2));
+    rc = seccomp_rule_add(data->ctx, action, syscall, 3, MRB_SECCOMP_CMP_FIND(args, 0), MRB_SECCOMP_CMP_FIND(args, 1),
+                          MRB_SECCOMP_CMP_FIND(args, 2));
     break;
   case 4:
-    rc = seccomp_rule_add(
-        data->ctx, action, syscall, 4, MRB_SECCOMP_CMP_FIND(args, 0),
-        MRB_SECCOMP_CMP_FIND(args, 1), MRB_SECCOMP_CMP_FIND(args, 2),
-        MRB_SECCOMP_CMP_FIND(args, 3));
+    rc = seccomp_rule_add(data->ctx, action, syscall, 4, MRB_SECCOMP_CMP_FIND(args, 0), MRB_SECCOMP_CMP_FIND(args, 1),
+                          MRB_SECCOMP_CMP_FIND(args, 2), MRB_SECCOMP_CMP_FIND(args, 3));
     break;
   case 5:
-    rc = seccomp_rule_add(
-        data->ctx, action, syscall, 5, MRB_SECCOMP_CMP_FIND(args, 0),
-        MRB_SECCOMP_CMP_FIND(args, 1), MRB_SECCOMP_CMP_FIND(args, 2),
-        MRB_SECCOMP_CMP_FIND(args, 3), MRB_SECCOMP_CMP_FIND(args, 4));
+    rc = seccomp_rule_add(data->ctx, action, syscall, 5, MRB_SECCOMP_CMP_FIND(args, 0), MRB_SECCOMP_CMP_FIND(args, 1),
+                          MRB_SECCOMP_CMP_FIND(args, 2), MRB_SECCOMP_CMP_FIND(args, 3), MRB_SECCOMP_CMP_FIND(args, 4));
     break;
   case 6:
-    rc = seccomp_rule_add(
-        data->ctx, action, syscall, 6, MRB_SECCOMP_CMP_FIND(args, 0),
-        MRB_SECCOMP_CMP_FIND(args, 1), MRB_SECCOMP_CMP_FIND(args, 2),
-        MRB_SECCOMP_CMP_FIND(args, 3), MRB_SECCOMP_CMP_FIND(args, 4),
-        MRB_SECCOMP_CMP_FIND(args, 5));
+    rc = seccomp_rule_add(data->ctx, action, syscall, 6, MRB_SECCOMP_CMP_FIND(args, 0), MRB_SECCOMP_CMP_FIND(args, 1),
+                          MRB_SECCOMP_CMP_FIND(args, 2), MRB_SECCOMP_CMP_FIND(args, 3), MRB_SECCOMP_CMP_FIND(args, 4),
+                          MRB_SECCOMP_CMP_FIND(args, 5));
     break;
   default:
-    mrb_raise(mrb, E_ARGUMENT_ERROR,
-              "Arg size exceeded to pass to seccomp_rule_add");
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "Arg size exceeded to pass to seccomp_rule_add");
     rc = -1;
     break;
   }
@@ -180,12 +172,14 @@ static mrb_value mrb_seccomp_add_rule(mrb_state *mrb, mrb_value self) {
   return mrb_fixnum_value(rc);
 }
 
-static mrb_value mrb_seccomp_load(mrb_state *mrb, mrb_value self) {
+static mrb_value mrb_seccomp_load(mrb_state *mrb, mrb_value self)
+{
   mrb_seccomp_data *data = DATA_PTR(self);
   return mrb_fixnum_value(seccomp_load(data->ctx));
 }
 
-static mrb_value mrb_seccomp_reset(mrb_state *mrb, mrb_value self) {
+static mrb_value mrb_seccomp_reset(mrb_state *mrb, mrb_value self)
+{
   mrb_seccomp_data *data = DATA_PTR(self);
   mrb_int new_def_action;
 
@@ -201,8 +195,8 @@ static mrb_value mrb_seccomp_reset(mrb_state *mrb, mrb_value self) {
   return mrb_fixnum_value(ret);
 }
 
-static void mrb_seccomp_sigaction(int signo, siginfo_t *siginfo,
-                                  void *_unused) {
+static void mrb_seccomp_sigaction(int signo, siginfo_t *siginfo, void *_unused)
+{
   if (!sig_mrb) {
     abort();
     return;
@@ -210,12 +204,12 @@ static void mrb_seccomp_sigaction(int signo, siginfo_t *siginfo,
 
   mrb_state *mrb = sig_mrb;
   struct RClass *seccomp = mrb_module_get(mrb, "Seccomp");
-  mrb_value proc = mrb_iv_get(mrb, mrb_obj_value(seccomp),
-                              mrb_intern_lit(mrb, "__ontrap_proc"));
+  mrb_value proc = mrb_iv_get(mrb, mrb_obj_value(seccomp), mrb_intern_lit(mrb, "__ontrap_proc"));
   mrb_funcall(mrb, proc, "call", 1, mrb_fixnum_value(siginfo->si_syscall));
 }
 
-static mrb_value mrb_seccomp_on_trap(mrb_state *mrb, mrb_value self) {
+static mrb_value mrb_seccomp_on_trap(mrb_state *mrb, mrb_value self)
+{
   mrb_value block;
   mrb_get_args(mrb, "&", &block);
 
@@ -232,39 +226,31 @@ static mrb_value mrb_seccomp_on_trap(mrb_state *mrb, mrb_value self) {
   }
 
   struct RClass *seccomp = mrb_module_get(mrb, "Seccomp");
-  mrb_iv_set(mrb, mrb_obj_value(seccomp), mrb_intern_lit(mrb, "__ontrap_proc"),
-             block);
+  mrb_iv_set(mrb, mrb_obj_value(seccomp), mrb_intern_lit(mrb, "__ontrap_proc"), block);
   return mrb_true_value();
 }
 
-#define MRB_SECCOMP_EXPORT_CONST(c)                                            \
-  mrb_define_const(mrb, parent, #c, mrb_fixnum_value(c))
+#define MRB_SECCOMP_EXPORT_CONST(c) mrb_define_const(mrb, parent, #c, mrb_fixnum_value(c))
 
 void mrb_mruby_seccomp_tracing_init(mrb_state *mrb, struct RClass *parent);
 
-void mrb_mruby_seccomp_gem_init(mrb_state *mrb) {
+void mrb_mruby_seccomp_gem_init(mrb_state *mrb)
+{
   struct RClass *parent, *context, *arg_cmp;
   parent = mrb_define_module(mrb, "Seccomp");
-  mrb_define_module_function(mrb, parent, "__gen_syscall_table",
-                             mrb_seccomp_generate_syscall_table,
-                             MRB_ARGS_NONE());
-  mrb_define_module_function(mrb, parent, "on_trap", mrb_seccomp_on_trap,
-                             MRB_ARGS_BLOCK());
+  mrb_define_module_function(mrb, parent, "__gen_syscall_table", mrb_seccomp_generate_syscall_table, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, parent, "on_trap", mrb_seccomp_on_trap, MRB_ARGS_BLOCK());
 
   context = mrb_define_class_under(mrb, parent, "Context", mrb->object_class);
   MRB_SET_INSTANCE_TT(context, MRB_TT_DATA);
-  mrb_define_method(mrb, context, "initialize", mrb_seccomp_init,
-                    MRB_ARGS_REQ(1));
-  mrb_define_method(mrb, context, "__add_rule", mrb_seccomp_add_rule,
-                    MRB_ARGS_REQ(3));
+  mrb_define_method(mrb, context, "initialize", mrb_seccomp_init, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, context, "__add_rule", mrb_seccomp_add_rule, MRB_ARGS_REQ(3));
   mrb_define_method(mrb, context, "load", mrb_seccomp_load, MRB_ARGS_NONE());
   mrb_define_method(mrb, context, "reset", mrb_seccomp_reset, MRB_ARGS_REQ(1));
 
-  arg_cmp =
-      mrb_define_class_under(mrb, parent, "ArgOperator", mrb->object_class);
+  arg_cmp = mrb_define_class_under(mrb, parent, "ArgOperator", mrb->object_class);
   MRB_SET_INSTANCE_TT(arg_cmp, MRB_TT_DATA);
-  mrb_define_method(mrb, arg_cmp, "initialize", mrb_seccomp_arg_cmp_init,
-                    MRB_ARGS_ARG(3, 4));
+  mrb_define_method(mrb, arg_cmp, "initialize", mrb_seccomp_arg_cmp_init, MRB_ARGS_ARG(3, 4));
 
   mrb_mruby_seccomp_tracing_init(mrb, parent);
 
@@ -282,4 +268,6 @@ void mrb_mruby_seccomp_gem_init(mrb_state *mrb) {
   DONE;
 }
 
-void mrb_mruby_seccomp_gem_final(mrb_state *mrb) {}
+void mrb_mruby_seccomp_gem_final(mrb_state *mrb)
+{
+}

--- a/src/syscall_table.c
+++ b/src/syscall_table.c
@@ -1,10 +1,10 @@
 #include <mruby.h>
 #include <mruby/data.h>
-#include <mruby/string.h>
 #include <mruby/hash.h>
+#include <mruby/string.h>
 #include <seccomp.h>
 
-#define MRB_SECCOMP_SET_SYSCALL(s)                                        mrb_hash_set(mrb, table, mrb_str_new_lit(mrb, #s), mrb_fixnum_value(SCMP_SYS(s)))
+#define MRB_SECCOMP_SET_SYSCALL(s) mrb_hash_set(mrb, table, mrb_str_new_lit(mrb, #s), mrb_fixnum_value(SCMP_SYS(s)))
 
 mrb_value mrb_seccomp_generate_syscall_table(mrb_state *mrb, mrb_value self)
 {
@@ -1301,7 +1301,6 @@ mrb_value mrb_seccomp_generate_syscall_table(mrb_state *mrb, mrb_value self)
 #ifdef __NR_bpf
   MRB_SECCOMP_SET_SYSCALL(bpf);
 #endif
-
 
   return table;
 }

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -74,6 +74,8 @@ static int mrb_seccomp_on_tracer_trap(mrb_state *mrb, mrb_value hook,
     mrb_sys_fail(mrb, "ptrace(PTRACE_GETREGS...");
   }
 
+  ptrace(PTRACE_DETACH, child, NULL, NULL);
+
   mrb_value args[3];
   args[0] = mrb_fixnum_value((int)regs.orig_rax); // syscall no
   args[1] = mrb_fixnum_value((int)child);         // pid
@@ -148,6 +150,7 @@ static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self) {
           if (mrb_seccomp_on_tracer_trap(mrb, hook, child) < 0) {
             mrb_raise(mrb, E_RUNTIME_ERROR, "Something is wrong in trap event");
           }
+          return self;
         }
       }
     } else if (WIFCONTINUED(status)) {

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -22,16 +22,16 @@
 #ifdef MRB_SECCOMP_DEBUG
 #define _log_p(fmt, ...) fprintf(stderr, fmt, ##__VA_ARGS__)
 #else
-#define _log_p(fmt, ...)                                                       \
-  if (0)                                                                       \
+#define _log_p(fmt, ...)                                                                                               \
+  if (0)                                                                                                               \
   printf(fmt, ##__VA_ARGS__)
 #endif
 
-#define MRB_PTRACE_DEFAULT_OPT                                                 \
-  (PTRACE_O_TRACEFORK | PTRACE_O_TRACEVFORK | PTRACE_O_TRACECLONE |            \
-   PTRACE_O_TRACEEXIT | PTRACE_O_TRACESECCOMP)
+#define MRB_PTRACE_DEFAULT_OPT                                                                                         \
+  (PTRACE_O_TRACEFORK | PTRACE_O_TRACEVFORK | PTRACE_O_TRACECLONE | PTRACE_O_TRACEEXIT | PTRACE_O_TRACESECCOMP)
 
-static void mrb_seccomp_userdata_free(mrb_state *mrb, void *p) {
+static void mrb_seccomp_userdata_free(mrb_state *mrb, void *p)
+{
   uint16_t *data = (uint16_t *)p;
   if (data)
     mrb_free(mrb, data);
@@ -41,7 +41,8 @@ static const struct mrb_data_type mrb_seccomp_tracer_type = {
     "mrb_seccomp_tracer_data", mrb_seccomp_userdata_free,
 };
 
-static mrb_value mrb_seccomp_tracer_init(mrb_state *mrb, mrb_value self) {
+static mrb_value mrb_seccomp_tracer_init(mrb_state *mrb, mrb_value self)
+{
   mrb_int userdata;
   uint16_t *value = mrb_malloc(mrb, sizeof(uint16_t));
 
@@ -54,7 +55,8 @@ static mrb_value mrb_seccomp_tracer_init(mrb_state *mrb, mrb_value self) {
   return self;
 }
 
-uint32_t mrb_seccomp_tracer_to_action(mrb_state *mrb, mrb_value self) {
+uint32_t mrb_seccomp_tracer_to_action(mrb_state *mrb, mrb_value self)
+{
   uint16_t *userdata = (uint16_t *)DATA_PTR(self);
   if (!userdata) {
     mrb_sys_fail(mrb, "[BUG] userdata is NULL");
@@ -62,8 +64,8 @@ uint32_t mrb_seccomp_tracer_to_action(mrb_state *mrb, mrb_value self) {
   return SCMP_ACT_TRACE(userdata[0]);
 }
 
-static int mrb_seccomp_on_tracer_trap(mrb_state *mrb, mrb_value hook,
-                                      pid_t child, int detach) {
+static int mrb_seccomp_on_tracer_trap(mrb_state *mrb, mrb_value hook, pid_t child, int detach)
+{
   unsigned long msg;
   struct user_regs_struct regs;
 
@@ -84,7 +86,8 @@ static int mrb_seccomp_on_tracer_trap(mrb_state *mrb, mrb_value hook,
   return 0;
 }
 
-static int mrb_seccomp_on_tracer_fork(mrb_state *mrb, pid_t child) {
+static int mrb_seccomp_on_tracer_fork(mrb_state *mrb, pid_t child)
+{
   unsigned long msg;
   pid_t pid;
 
@@ -100,7 +103,8 @@ static int mrb_seccomp_on_tracer_fork(mrb_state *mrb, pid_t child) {
 #define MRB_PTRACE_EVENT(status) (((status >> 8) ^ SIGTRAP) >> 8)
 
 /* This method is implemented unser Seccomp root module */
-static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self, int detach) {
+static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self, int detach)
+{
   mrb_int pid;
   mrb_value hook;
   int status, child;
@@ -110,8 +114,7 @@ static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self, int de
   }
   waitpid(pid, &status, 0);
 
-  if (ptrace(PTRACE_SETOPTIONS, pid, NULL, (void *)MRB_PTRACE_DEFAULT_OPT) ==
-      -1) {
+  if (ptrace(PTRACE_SETOPTIONS, pid, NULL, (void *)MRB_PTRACE_DEFAULT_OPT) == -1) {
     mrb_sys_fail(mrb, "ptrace(PTRACE_SETOPTIONS...");
   }
   if (ptrace(PTRACE_CONT, pid, NULL, NULL) == -1) {
@@ -139,20 +142,18 @@ static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self, int de
       }
     } else if (WIFSTOPPED(status)) {
       if (WSTOPSIG(status) == SIGTRAP) {
-        if (MRB_PTRACE_EVENT(status) == PTRACE_EVENT_FORK ||
-            MRB_PTRACE_EVENT(status) == PTRACE_EVENT_VFORK) {
+        if (MRB_PTRACE_EVENT(status) == PTRACE_EVENT_FORK || MRB_PTRACE_EVENT(status) == PTRACE_EVENT_VFORK) {
           _log_p("Debug: fork is invoked\n");
           if (mrb_seccomp_on_tracer_fork(mrb, child) < 0) {
-            mrb_raise(mrb, E_RUNTIME_ERROR,
-                      "Something is wrong when grandchildren fork");
+            mrb_raise(mrb, E_RUNTIME_ERROR, "Something is wrong when grandchildren fork");
           }
         } else if (MRB_PTRACE_EVENT(status) == PTRACE_EVENT_SECCOMP) {
           if (mrb_seccomp_on_tracer_trap(mrb, hook, child, detach) < 0) {
             mrb_raise(mrb, E_RUNTIME_ERROR, "Something is wrong in trap event");
           }
-	  if (detach) {
+          if (detach) {
             return self;
-	  }
+          }
         }
       }
     } else if (WIFCONTINUED(status)) {
@@ -163,32 +164,28 @@ static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self, int de
 
     if (ptrace(PTRACE_CONT, child, NULL, NULL) < 0) {
       if (!children_exit) {
-        mrb_raisef(mrb, E_RUNTIME_ERROR,
-                   "Cannot continue process: %d. Force to kill",
-                   mrb_fixnum_value(child));
+        mrb_raisef(mrb, E_RUNTIME_ERROR, "Cannot continue process: %d. Force to kill", mrb_fixnum_value(child));
       }
     }
     children_exit = FALSE;
   }
 }
-static mrb_value mrb_seccomp_ptrace(mrb_state *mrb, mrb_value self){
+static mrb_value mrb_seccomp_ptrace(mrb_state *mrb, mrb_value self)
+{
   return mrb_seccomp_start_ptrace(mrb, self, FALSE);
 }
 
-static mrb_value mrb_seccomp_ptrace_detach(mrb_state *mrb, mrb_value self){
+static mrb_value mrb_seccomp_ptrace_detach(mrb_state *mrb, mrb_value self)
+{
   return mrb_seccomp_start_ptrace(mrb, self, TRUE);
 }
 
-void mrb_mruby_seccomp_tracing_init(mrb_state *mrb, struct RClass *parent) {
-  struct RClass *tracer =
-      mrb_define_class_under(mrb, parent, "Tracer", mrb->object_class);
+void mrb_mruby_seccomp_tracing_init(mrb_state *mrb, struct RClass *parent)
+{
+  struct RClass *tracer = mrb_define_class_under(mrb, parent, "Tracer", mrb->object_class);
   MRB_SET_INSTANCE_TT(tracer, MRB_TT_DATA);
-  mrb_define_method(mrb, tracer, "initialize", mrb_seccomp_tracer_init,
-                    MRB_ARGS_REQ(1));
-  mrb_define_module_function(mrb, parent, "start_trace",
-                             mrb_seccomp_ptrace,
-                             MRB_ARGS_REQ(1) | MRB_ARGS_BLOCK());
-  mrb_define_module_function(mrb, parent, "start_trace_detach",
-                             mrb_seccomp_ptrace_detach,
+  mrb_define_method(mrb, tracer, "initialize", mrb_seccomp_tracer_init, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, parent, "start_trace", mrb_seccomp_ptrace, MRB_ARGS_REQ(1) | MRB_ARGS_BLOCK());
+  mrb_define_module_function(mrb, parent, "start_trace_detach", mrb_seccomp_ptrace_detach,
                              MRB_ARGS_REQ(1) | MRB_ARGS_BLOCK());
 }

--- a/test/test_seccomp_context.rb
+++ b/test/test_seccomp_context.rb
@@ -62,3 +62,20 @@ assert("Seccomp.start_trace with forking processes") do
   assert_equal "exited", ret
   assert_equal 10, count
 end
+
+assert("Seccomp.start_trace_detach") do
+  pid = Process.fork do
+    ctx = Seccomp.new(default: :allow) do |rule|
+      rule.trace(:uname, 0)
+    end
+    ctx.load
+    exec '/bin/bash', '-c', 'exec uname -a >/dev/null'
+  end
+
+  count = 0
+  ret = Seccomp.start_trace_detach(pid) do |syscall, ud|
+    count += 1
+  end
+  assert_not_equal "exited", ret
+  assert_equal 1, count
+end


### PR DESCRIPTION
When tracing a system call, ```PTRACE_DETACH``` is used when traping by using ```Seccomp.start_trace_detach```.
The process is restarted after being detached by using ```PTRACE_DETACH```. This makes it possible to process such as dumping a process by hooking an arbitrary system call.

```
pid = Process.fork do
  context = Seccomp.new(default: :allow) do |rule|
    rule.trace(:uname, 0)
  end
  context.load
  exec '/bin/bash', '-c', 'exec uname -a'
end
ret = Seccomp.start_trace_detach(pid) do |syscall, ud|
    # dump something...
end
```