### PR TITLE
Get tracing process state using 'Process::status'

### DIFF
--- a/examples/tracing.rb
+++ b/examples/tracing.rb
@@ -11,9 +11,10 @@ pid = Process.fork do
   #exec '/bin/bash', '-l'
 end
 
+p $?.inspect
 ret = Seccomp.start_trace(pid) do |syscall, _pid, ud|
   name = Seccomp.syscall_to_name(syscall)
   puts "[#{_pid}]: syscall #{name}(##{syscall}) called. (ud: #{ud})"
 end
 
-p(ret)
+p $?.exited?

--- a/examples/tracing.rb
+++ b/examples/tracing.rb
@@ -17,4 +17,5 @@ ret = Seccomp.start_trace(pid) do |syscall, _pid, ud|
   puts "[#{_pid}]: syscall #{name}(##{syscall}) called. (ud: #{ud})"
 end
 
+p ret.exited?
 p $?.exited?

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -105,7 +105,9 @@ static int mrb_seccomp_on_tracer_fork(mrb_state *mrb, pid_t child)
 static mrb_value mrb_process_status_new(mrb_state *mrb, mrb_int pid, mrb_int stat)
 {
   struct RClass *status_cls = mrb_class_get_under(mrb, mrb_module_get(mrb, "Process"), "Status");
-  return mrb_funcall(mrb, mrb_obj_value(status_cls), "new", 2, mrb_fixnum_value(pid), mrb_fixnum_value(stat));
+  mrb_value ret = mrb_funcall(mrb, mrb_obj_value(status_cls), "new", 2, mrb_fixnum_value(pid), mrb_fixnum_value(stat));
+  mrb_gv_set(mrb, mrb_intern_lit(mrb, "$?"), ret);
+  return ret;
 }
 /* This method is implemented unser Seccomp root module */
 static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self, int detach)

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -102,6 +102,11 @@ static int mrb_seccomp_on_tracer_fork(mrb_state *mrb, pid_t child)
 
 #define MRB_PTRACE_EVENT(status) (((status >> 8) ^ SIGTRAP) >> 8)
 
+static mrb_value mrb_process_status_new(mrb_state *mrb, mrb_int pid, mrb_int stat)
+{
+  struct RClass *status_cls = mrb_class_get_under(mrb, mrb_module_get(mrb, "Process"), "Status");
+  return mrb_funcall(mrb, mrb_obj_value(status_cls), "new", 2, mrb_fixnum_value(pid), mrb_fixnum_value(stat));
+}
 /* This method is implemented unser Seccomp root module */
 static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self, int detach)
 {
@@ -120,27 +125,24 @@ static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self, int de
   if (ptrace(PTRACE_CONT, pid, NULL, NULL) == -1) {
     mrb_sys_fail(mrb, "ptrace(PTRACE_CONT...");
   }
-  struct RClass *status_cls = mrb_class_get_under(mrb, mrb_module_get(mrb, "Process"), "Status");
 
   int children_exit = FALSE;
   while (1) {
     child = waitpid(-1, &status, WUNTRACED | WCONTINUED | __WALL);
 
-    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$?"),
-               mrb_funcall(mrb, mrb_obj_value(status_cls), "new", 2, mrb_fixnum_value(pid), mrb_fixnum_value(status)));
     if (child == -1) {
       mrb_sys_fail(mrb, "waitpid");
     }
 
     if (WIFEXITED(status)) {
       if (child == pid) {
-        return mrb_fixnum_value(pid);
+        return mrb_process_status_new(mrb, pid, status);
       } else {
         children_exit = TRUE;
       }
     } else if (WIFSIGNALED(status)) {
       if (child == pid) {
-        return mrb_fixnum_value(pid);
+        return mrb_process_status_new(mrb, pid, status);
       } else {
         children_exit = TRUE;
       }
@@ -156,7 +158,7 @@ static mrb_value mrb_seccomp_start_ptrace(mrb_state *mrb, mrb_value self, int de
             mrb_raise(mrb, E_RUNTIME_ERROR, "Something is wrong in trap event");
           }
           if (detach) {
-            return self;
+            return mrb_process_status_new(mrb, pid, status);
           }
         }
       }

--- a/test/test_seccomp_context.rb
+++ b/test/test_seccomp_context.rb
@@ -40,8 +40,7 @@ assert("Seccomp.start_trace") do
   ret = Seccomp.start_trace(pid) do |syscall, ud|
     count += 1
   end
-
-  assert_equal "exited", ret
+  assert_true $?.exited?
   assert_equal 4, count
 end
 
@@ -58,8 +57,7 @@ assert("Seccomp.start_trace with forking processes") do
   ret = Seccomp.start_trace(pid) do |syscall, ud|
     count += 1
   end
-
-  assert_equal "exited", ret
+  assert_true $?.exited?
   assert_equal 10, count
 end
 
@@ -76,6 +74,6 @@ assert("Seccomp.start_trace_detach") do
   ret = Seccomp.start_trace_detach(pid) do |syscall, ud|
     count += 1
   end
-  assert_not_equal "exited", ret
+  assert_false $?.exited?
   assert_equal 1, count
 end

--- a/test/test_seccomp_context.rb
+++ b/test/test_seccomp_context.rb
@@ -41,6 +41,7 @@ assert("Seccomp.start_trace") do
     count += 1
   end
   assert_true ret.exited?
+  assert_true $?.exited?
   assert_equal 4, count
 end
 
@@ -58,6 +59,7 @@ assert("Seccomp.start_trace with forking processes") do
     count += 1
   end
   assert_true ret.exited?
+  assert_true $?.exited?
   assert_equal 10, count
 end
 
@@ -75,5 +77,6 @@ assert("Seccomp.start_trace_detach") do
     count += 1
   end
   assert_false ret.exited?
+  assert_false $?.exited?
   assert_equal 1, count
 end

--- a/test/test_seccomp_context.rb
+++ b/test/test_seccomp_context.rb
@@ -40,7 +40,7 @@ assert("Seccomp.start_trace") do
   ret = Seccomp.start_trace(pid) do |syscall, ud|
     count += 1
   end
-  assert_true $?.exited?
+  assert_true ret.exited?
   assert_equal 4, count
 end
 
@@ -57,7 +57,7 @@ assert("Seccomp.start_trace with forking processes") do
   ret = Seccomp.start_trace(pid) do |syscall, ud|
     count += 1
   end
-  assert_true $?.exited?
+  assert_true ret.exited?
   assert_equal 10, count
 end
 
@@ -74,6 +74,6 @@ assert("Seccomp.start_trace_detach") do
   ret = Seccomp.start_trace_detach(pid) do |syscall, ud|
     count += 1
   end
-  assert_false $?.exited?
+  assert_false ret.exited?
   assert_equal 1, count
 end


### PR DESCRIPTION
```start_trace``` and ```start_trace_detach``` returned symbols such as "exited" and "signaled" until now. 
So, I set the state of tracing process to ```$?```.```$?``` variable contains the "Process::Status" object. 
If we want to confirm that the process is exited, we can check with ```$?.exited?```.

## example code
```
pid = Process.fork do
  context = Seccomp.new(default: :allow) do |rule|
    rule.trace(:getuid, 0)
    rule.trace(:uname, 0)
  end
  context.load

  # uname will be called 10 times: 1 in bash, 3 * 3 in uname(1)
  exec '/bin/bash', '-c', 'uname -a; uname -a; uname -a'
  #exec '/bin/bash', '-c', 'exec uname -a'
  #exec '/bin/bash', '-l'
end

ret = Seccomp.start_trace(pid) do |syscall, _pid, ud|
  name = Seccomp.syscall_to_name(syscall)
  puts "[#{_pid}]: syscall #{name}(##{syscall}) called. (ud: #{ud})"
end

p $?.exited? #=> true
```